### PR TITLE
Исправление зависания установщика на ARM-архитектуре

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -35,12 +35,13 @@ mkdir -p "$BASE_DIR"
 show_spinner() {
     local pid=$1
     local text=$2
-    local level=${3:-0} # Default level is 0 if not provided
+    local level=${3:-0}
     local spinstr='/-\|'
     local delay=0.1
-    local indent=$(printf "%*s" $((level * 2)) "") # Indentation based on level
+    local indent=$(printf "%*s" $((level * 2)) "")
 
-    while kill -0 $pid 2>/dev/null; do
+    # Более надежная проверка существования PID в Linux
+    while [ -d "/proc/$pid" ]; do
         for char in $spinstr; do
             printf "\r%s%s %c" "$indent" "$text" "$char"
             sleep $delay


### PR DESCRIPTION
Исправляет критический баг в скрипте инициализации (`installer.sh`), из-за которого процесс установки намертво зависал на шаге **"Загрузка и настройка проекта"** (а также потенциально на других быстрых шагах) при запуске на ARM-архитектуре.

Функция `show_spinner` проверяла статус выполнения фонового процесса с помощью конструкции `while kill -0 $pid`. 
На ARM-системах (особенно при использовании дефолтной для Ubuntu оболочки `/bin/sh` -> `dash`) быстрые фоновые подоболочки `(...) &` (например, связка `curl` + `sed` внутри `download_project`) завершались быстрее, чем спиннер успевал корректно перехватить изменение состояния. В итоге `kill -0` продолжал возвращать `0`, уводя спиннер в бесконечный цикл.