### PR TITLE
Более коректная обработка анимации спиннера

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -37,18 +37,25 @@ show_spinner() {
     local text="$2"
     local level="${3:-0}" # Default level is 0 if not provided
     local delay=0.1
-    local indent=$(printf "%*s" $((level * 2)) "") # Indentation based on level
+    local indent
 
-    while kill -0 $pid 2>/dev/null; do
-        for char in $spinstr; do
-            printf "\r%s%s %c" "$indent" "$text" "$char"
-            sleep "$delay"
+    indent=$(printf "%*s" $((level * 2)) "") # Indentation based on level
+
+    (
+        while :; do
+            for char in "/" "-" "\\" "|"; do
+                printf "\r%s%s %s" "$indent" "$text" "$char"
+                sleep "$delay"
+            done
         done
-    done
+    ) &
+    local spinner_pid="$!"
 
     wait "$pid"
     local result="$?"
 
+    kill "$spinner_pid" 2>/dev/null || true
+    wait "$spinner_pid" 2>/dev/null || true
 
     if [ "$result" -eq 0 ]; then
         printf "\r%s%s \033[32m✓\033[0m\n" "$indent" "$text"

--- a/installer.sh
+++ b/installer.sh
@@ -33,30 +33,30 @@ mkdir -p "$BASE_DIR"
 
 # Function to display a spinner with support for nested tasks
 show_spinner() {
-    local pid=$1
-    local text=$2
-    local level=${3:-0} # Default level is 0 if not provided
-    local spinstr='/-\|'
+    local pid="$1"
+    local text="$2"
+    local level="${3:-0}" # Default level is 0 if not provided
     local delay=0.1
     local indent=$(printf "%*s" $((level * 2)) "") # Indentation based on level
 
     while kill -0 $pid 2>/dev/null; do
         for char in $spinstr; do
             printf "\r%s%s %c" "$indent" "$text" "$char"
-            sleep $delay
+            sleep "$delay"
         done
     done
 
-    wait $pid
-    local result=$?
+    wait "$pid"
+    local result="$?"
 
-    if [ $result -eq 0 ]; then
+
+    if [ "$result" -eq 0 ]; then
         printf "\r%s%s \033[32m✓\033[0m\n" "$indent" "$text"
     else
         printf "\r%s%s \033[31m✗\033[0m\n" "$indent" "$text"
     fi
 
-    return $result
+    return "$result"
 }
 
 # Disable additional notifications


### PR DESCRIPTION
1 Добавил экранирование (только в этот модуль)
2 Раньше спиннер пытался сам понять, жив ли процесс, проверяя PID. Это могло зависнуть или работать по-разному на разных системах ([другой PR сообщающий от этой проблеме](https://github.com/Gml-Launcher/Gml.Backend.Installer/pull/26)). Теперь спиннер крутится отдельно, пока shell ждёт основную команду через wait "$pid". Когда команда завершается, мы получаем её exit code и после чего останавливаем спиннер.

Протестировано  на:
* x86 Ubuntu 26
* armv7 (Raspberry pi 4), спиннер не доставил проблем, но запустить не получилось, так как образы не поддерживают armv7
